### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Linear, providing tools for issue tracking and project management.
 
+<a href="https://glama.ai/mcp/servers/4t9pgjso9u">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/4t9pgjso9u/badge" alt="Linear Server MCP server" />
+</a>
+
 ## Configuration
 
 Go to [Linear security settings](https://linear.app/settings/account/security) and create an API key:


### PR DESCRIPTION
This PR adds a badge for the [Linear MCP Server](https://glama.ai/mcp/servers/4t9pgjso9u) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4t9pgjso9u">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/4t9pgjso9u/badge" alt="Linear Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.